### PR TITLE
Refactoring

### DIFF
--- a/manifest/application.yaml.template
+++ b/manifest/application.yaml.template
@@ -26,6 +26,19 @@ spec:
     links:
     - description: Getting Started
       url: https://www.conjur.org/get-started/
+    notes: |-
+      # Access Conjur
+
+      You can view the Conjur Status Dashboard at the address listed on the table to the left.
+
+      Note that it might take some time for the external IP to be provisioned.
+
+      # Configure Conjur
+
+      To create an initial account and login, follow the instructions here:
+      https://www.conjur.org/get-started/install-conjur.html#install-and-configure
+
+      Use `kubectl exec <conjur-pod> ...` instead of `docker-compose exec ...`.
   selector:
     matchLabels:
       app.kubernetes.io/name: "$name"
@@ -36,26 +49,10 @@ spec:
     kind: Secret
   - group: v1
     kind: Service
-  notes: |-
-    # Access Conjur
+  info:
+  - name: Conjur Status Dashboard IP
+    type: Reference
+    valueFrom:
+      serviceRef:
+        name: $name-conjur
 
-    Get the external IP of the Conjur service and visit
-      the URL printed below in your browser to see the status page.
-
-      ```
-      SERVICE_IP=$(kubectl get \
-        --namespace ${namespace} \
-        svc ${name} \
-        -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-
-      echo "http://${SERVICE_IP}"
-      ```
-
-      Note that it might take some time for the external IP to be provisioned.
-
-    # Configure Conjur
-
-    To create an initial account and login, follow the instructions here:
-      https://www.conjur.org/get-started/install-conjur.html#install-and-configure
-
-      Use `kubectl exec <conjur-pod> ...` instead of `docker-compose exec ...`.

--- a/manifest/manifests.yaml.template
+++ b/manifest/manifests.yaml.template
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/component: $name-service
 type: Opaque
 data:
-  key: "$conjurDatabaseUrl"
+  key: "$conjurDatabaseUrlEncoded"
 ---
 apiVersion: v1
 kind: Service

--- a/manifest/manifests.yaml.template
+++ b/manifest/manifests.yaml.template
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: postgres
+  name: $name-postgres
   labels:
     app.kubernetes.io/name: $name
     app.kubernetes.io/component: $name-postgres
@@ -15,7 +15,7 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: postgres
+  name: $name-postgres
   labels:
     app.kubernetes.io/name: $name
     app.kubernetes.io/component: $name-postgres
@@ -33,7 +33,7 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: conjur-data-key
+  name: $name-conjur-data-key
   labels:
     app.kubernetes.io/name: $name
     app.kubernetes.io/component: $name-service
@@ -44,7 +44,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: conjur-database-url
+  name: $name-conjur-database-url
   labels:
     app.kubernetes.io/name: $name
     app.kubernetes.io/component: $name-service
@@ -55,7 +55,7 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: conjur
+  name: $name-conjur
   labels:
     app: $name
     app.kubernetes.io/name: $name
@@ -75,7 +75,7 @@ metadata:
     app: $name
     app.kubernetes.io/name: $name
     app.kubernetes.io/component: $name-service
-  name: conjur
+  name: $name-conjur
 spec:
   replicas: 1
   selector:
@@ -101,10 +101,10 @@ spec:
         - name: CONJUR_DATA_KEY
           valueFrom:
             secretKeyRef:
-              name: conjur-data-key
+              name: $name-conjur-data-key
               key: key
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:
-              name: conjur-database-url
+              name: $name-conjur-database-url
               key: key

--- a/manifest/manifests.yaml.template
+++ b/manifest/manifests.yaml.template
@@ -22,7 +22,7 @@ spec:
   replicas: 1
   template:
     metadata:
-      labels: *&AppPostgresLabels
+      labels: *AppPostgresLabels
     spec:
       containers:
       - image: $imagePostgres

--- a/manifest/manifests.yaml.template
+++ b/manifest/manifests.yaml.template
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: $name-postgres
+  name: postgres
   labels: &AppPostgresLabels
     app.kubernetes.io/name: $name
     app.kubernetes.io/component: postgres

--- a/manifest/manifests.yaml.template
+++ b/manifest/manifests.yaml.template
@@ -3,28 +3,26 @@ apiVersion: v1
 kind: Service
 metadata:
   name: $name-postgres
-  labels:
+  labels: &AppPostgresLabels
     app.kubernetes.io/name: $name
-    app.kubernetes.io/component: $name-postgres
+    app.kubernetes.io/component: postgres
 spec:
   ports:
   - port: 5432
-  selector:
-    app: postgres
+  selector: *AppPostgresLabels
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: $name-postgres
-  labels:
+  labels: &AppPostgresLabels
     app.kubernetes.io/name: $name
-    app.kubernetes.io/component: $name-postgres
+    app.kubernetes.io/component: postgres
 spec:
   replicas: 1
   template:
     metadata:
-      labels:
-        app: postgres
+      labels: *&AppPostgresLabels
     spec:
       containers:
       - image: $imagePostgres
@@ -36,7 +34,7 @@ metadata:
   name: $name-conjur-data-key
   labels:
     app.kubernetes.io/name: $name
-    app.kubernetes.io/component: $name-service
+    app.kubernetes.io/component: service
 type: Opaque
 data:
   key: "$conjurDataKey"
@@ -47,7 +45,7 @@ metadata:
   name: $name-conjur-database-url
   labels:
     app.kubernetes.io/name: $name
-    app.kubernetes.io/component: $name-service
+    app.kubernetes.io/component: service
 type: Opaque
 data:
   key: "$conjurDatabaseUrlEncoded"
@@ -56,38 +54,30 @@ apiVersion: v1
 kind: Service
 metadata:
   name: $name-conjur
-  labels:
-    app: $name
+  labels: &AppConjurLabels
     app.kubernetes.io/name: $name
-    app.kubernetes.io/component: $name-service
+    app.kubernetes.io/component: service
 spec:
   ports:
   - port: 80
     name: http
-  selector:
-    app: $name
+  selector: *AppConjurLabels
   type: LoadBalancer
 ---
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  labels:
-    app: $name
-    app.kubernetes.io/name: $name
-    app.kubernetes.io/component: $name-service
   name: $name-conjur
+  labels: &AppConjurLabels
+    app.kubernetes.io/name: $name
+    app.kubernetes.io/component: service
 spec:
   replicas: 1
   selector:
-    matchLabels:
-      app: $name
+    matchLabels: *AppConjurLabels
   template:
     metadata:
-      labels:
-        app: $name
-        name: $name
-        app.kubernetes.io/name: $name
-        app.kubernetes.io/component: $name-service
+      labels: *AppConjurLabels
     spec:
       containers:
       - name: conjur

--- a/schema.yaml
+++ b/schema.yaml
@@ -30,8 +30,13 @@ properties:
   conjurDatabaseUrl:
     type: string
     title: PostgreSQL connection
-    description: PostgreSQL connection string for Conjur. This string must be base64-encoded.
-    default: 'cG9zdGdyZXM6Ly9wb3N0Z3Jlc0Bwb3N0Z3Jlcy9wb3N0Z3Jlcw=='  # postgres://postgres@postgres/postgres.
+    description: PostgreSQL connection string for Conjur.
+    default: 'postgres://postgres@postgres/postgres'
+    x-google-marketplace:
+      type: STRING
+      string:
+        generatedProperties:
+          base64Encoded: conjurDatabaseUrlEncoded
 required:
 - name
 - namespace

--- a/schema.yaml
+++ b/schema.yaml
@@ -31,7 +31,7 @@ properties:
     type: string
     title: PostgreSQL connection
     description: PostgreSQL connection string for Conjur.
-    default: 'postgres://postgres@$name-postgres/postgres'
+    default: 'postgres://postgres@postgres/postgres'
     x-google-marketplace:
       type: STRING
       string:


### PR DESCRIPTION
@dustinmm80 Sorry, it looks like we need to restore the static name for the service (`postgres`), because the dynamic one cannot be configured as a default value for the connection string (in `schema.yaml`). In such case, having the connection URL configurable, requires the service name to be static. This is an issue to be followed up.

Other than that:
1. The selectors for services could have matched pods not belonging to the Kubernetes app deployment (as far as another app deployment existed in the same namespace)
1. The labels for `app` and `name` seem to be unnecessary after changing the selectors.
1. The references for labels (e.g. `AppConjurLabels`) make it easier to reuse the values.
1. The notes item in the Application's spec seemed to be mistakenly indented (fixed).
1. The info table provides an easier way to use mechanism for accessing the IP address of a Service - with this information, the notes section can also be simplified.