### PR TITLE
Update namespace to render properly

### DIFF
--- a/conjur/templates/application.yaml
+++ b/conjur/templates/application.yaml
@@ -34,7 +34,7 @@ spec:
 
         ```
         kubectl patch svc "{{ .Release.Name }}-conjur" \
-          --namespace "$namespace" \
+          --namespace {{ .Release.Namespace }} \
           -p '{"spec": {"type": "LoadBalancer"}}'
         ```
 


### PR DESCRIPTION
When referencing the namespace with `$namespace` on the post-deploy page, it was rendered as a literal string, rather than a variable. Updating this to match other namespace references. 
![namespace](https://user-images.githubusercontent.com/21086745/45658446-c4439880-baa3-11e8-8a54-958aff838cdb.png)

