### PR TITLE
Update chart to v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/cyberark/conjur-google-cloud-launcher/releases/tag/v1.2.0) - 2018-12-06
+### Changed
+- Authenticators parameter was added to configuration UI. See [conjur-oss Helm chart configuration](https://github.com/cyberark/conjur-oss-helm-chart/tree/master/conjur-oss#configuration).
+
 ## [1.1.0](https://github.com/cyberark/conjur-google-cloud-launcher/releases/tag/v1.1.0) - 2018-08-10
 ### Changed
 - Helm chart now comes from https://github.com/cyberark/conjur-oss-helm-chart

--- a/conjur/Chart.yaml
+++ b/conjur/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A Helm chart for CyberArk Conjur
 name: conjur
-version: 1.1.0
+version: 1.2.0
 icon: https://xebialabs-clients-iglusjax.stackpathdns.com/assets/files/logos/CyberArkConjurLogoWhiteBlue.png

--- a/conjur/requirements.yaml
+++ b/conjur/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: conjur-oss
-    version: "0.2.1"
+    version: "0.2.2"
     repository: https://cyberark.github.io/helm-charts
     alias: conjuross  # aliased to remove '-' in conjur-oss. Downstream tools have problems without this.

--- a/conjur/templates/application.yaml
+++ b/conjur/templates/application.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   descriptor:
     type: Conjur
-    version: '1.1.0'
+    version: '1.2.0'
     description: |-
       CyberArk Conjur automatically secures secrets used by privileged users and machine identities.
 

--- a/schema.yaml
+++ b/schema.yaml
@@ -29,6 +29,13 @@ properties:
           splitByColon:
             before: postgres.repository
             after: postgres.tag
+  conjuross.authenticators:
+    type: string
+    default: authn
+    title: Conjur Authenticators
+    description: >-
+      Comma-separated list of authenticators to enable on Conjur.
+      See the full list at https://docs.conjur.org/Latest/en/Content/Operations/Services/authentication-types.htm.
   conjuross.dataKey:
     type: string
     title: Conjur Data key


### PR DESCRIPTION
This updates the dependency to v0.2.2 and adds `authenticators` parameter to the marketplace UI.