### PR TITLE
Update the build with v1.3.6 of conjur-oss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ conjur/charts/
 conjur/requirements.lock
 
 .DS_Store
+
+# VIM swapfiles
+*.sw[po]

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .build/
+ci/.tmp/
 conjur/charts/
 conjur/requirements.lock
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.3.4](https://github.com/cyberark/conjur-google-cloud-launcher/releases/tag/v1.3.4) - 2019-01-08
+### Changed
+- Dependency on Conjur OSS helm chart updated to newest release
+
 ## [1.2.0](https://github.com/cyberark/conjur-google-cloud-launcher/releases/tag/v1.2.0) - 2018-12-06
 ### Changed
 - Authenticators parameter was added to configuration UI. See [conjur-oss Helm chart configuration](https://github.com/cyberark/conjur-oss-helm-chart/tree/master/conjur-oss#configuration).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 1. Clone the repository:
 
-    `$ git clone _this_repo_address_`
+    `$ git clone git@github.com:cyberark/conjur-google-cloud-marketplace.git`
 
 2. Update the Google Cloud Launcher [submodules|git-submodules]:
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,9 +15,15 @@ pipeline {
         sh 'git submodule update --recursive --init --force'
       }
     }
-    stage('Verify application') {
+
+    stage('GKE build-test-verify-publish') {
+      when {
+        anyOf {
+          branch 'master'
+        }
+      }
       steps {
-        sh './test.sh'
+        sh 'cd ci && summon ./gke_test'
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,22 +9,17 @@ pipeline {
   }
 
   stages {
-    stage('Stubbed until GCL goes live') {
+    stage('Fetch marketplace submodule') {
       steps {
-        sh 'exit 0'
+        sh 'git submodule sync --recursive'
+        sh 'git submodule update --recursive --init --force'
       }
     }
-    // stage('Fetch marketplace submodule') {
-    //   steps {
-    //     sh 'git submodule sync --recursive'
-    //     sh 'git submodule update --recursive --init --force'
-    //   }
-    // }
-    // stage('Verify application') {
-    //   steps {
-    //     sh './test.sh'
-    //   }
-    // }
+    stage('Verify application') {
+      steps {
+        sh './test.sh'
+      }
+    }
   }
 
   post {

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ POSTGRES_SOURCE_IMAGE ?= postgres:10.1
 POSTGRES_IMAGE ?= $(REGISTRY)/$(PREFIX)/postgres:$(TAG)
 NGINX_SOURCE_IMAGE ?= nginx:1.15
 NGINX_IMAGE ?= $(REGISTRY)/$(PREFIX)/nginx:$(TAG)
+DOCKERFILE ?= deployer/Dockerfile
 
 APP_PARAMETERS ?= { \
   "name": "$(NAME)", \
@@ -67,8 +68,9 @@ app/build:: .build/conjur/deployer \
 	docker build \
 	    --build-arg REGISTRY="$(REGISTRY)" \
 	    --build-arg TAG="$(TAG)" \
+	    --build-arg CONJUR_OSS_PACKAGE="$(CONJUR_OSS_PACKAGE)" \
 	    --tag "$(APP_DEPLOYER_IMAGE)" \
-	    -f deployer/Dockerfile \
+	    -f "$(DOCKERFILE)" \
 	    .
 	docker push "$(APP_DEPLOYER_IMAGE)"
 	@touch "$@"

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ APP_PARAMETERS ?= { \
   "conjur.image": "$(CONJUR_IMAGE)", \
   "postgres.image": "$(POSTGRES_IMAGE)" \
   "nginx.image": "$(NGINX_IMAGE)" \
+	"conjuross.account": "" \
+	"conjuross.authenticator": "" \
+	"ssl.hostname": "conjur.myorg.com" \
 }
 TESTER_IMAGE ?= $(REGISTRY)/$(PREFIX)/tester:$(TAG)
 APP_TEST_PARAMETERS ?= { \

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,9 @@ APP_PARAMETERS ?= { \
   "conjur.image": "$(CONJUR_IMAGE)", \
   "postgres.image": "$(POSTGRES_IMAGE)" \
   "nginx.image": "$(NGINX_IMAGE)" \
-	"conjuross.account": "" \
-	"conjuross.authenticator": "" \
-	"ssl.hostname": "conjur.myorg.com" \
+  "conjuross.account": "" \
+  "conjuross.authenticator": "" \
+  "ssl.hostname": "conjur.myorg.com" \
 }
 TESTER_IMAGE ?= $(REGISTRY)/$(PREFIX)/tester:$(TAG)
 APP_TEST_PARAMETERS ?= { \

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,7 @@ APP_PARAMETERS ?= { \
 }
 TESTER_IMAGE ?= $(REGISTRY)/$(PREFIX)/tester:$(TAG)
 APP_TEST_PARAMETERS ?= { \
-  "tester.image": "$(TESTER_IMAGE)", \
-	"conjuross.image.tag": "$(TAG)", \
-	"conjuross.nginx.tag": "$(TAG)", \
-	"conjuross.postgres.tag": "$(TAG)" \
+  "tester.image": "$(TESTER_IMAGE)" \
 }
 
 # Extend the target as defined in app.Makefile to

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,6 @@ APP_PARAMETERS ?= { \
   "conjur.image": "$(CONJUR_IMAGE)", \
   "postgres.image": "$(POSTGRES_IMAGE)" \
   "nginx.image": "$(NGINX_IMAGE)" \
-  "conjuross.account": "" \
-  "conjuross.authenticator": "" \
-  "ssl.hostname": "conjur.myorg.com" \
 }
 TESTER_IMAGE ?= $(REGISTRY)/$(PREFIX)/tester:$(TAG)
 APP_TEST_PARAMETERS ?= { \

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ include var.Makefile
 # app.Makefile provides the main targets for installing the
 # application.
 # It requires several APP_* variables defined as followed.
-#include ./makefiles/app.Makefile
+# This file is forked from https://raw.githubusercontent.com/GoogleCloudPlatform/click-to-deploy/master/k8s/app.Makefile
+include app.Makefile
 
 NAME ?= conjur
 

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,26 @@
 TAG ?= 1.3
 
 # crd.Makefile provides targets to install Application CRD.
-include ./marketplace-k8s-app-tools/crd.Makefile
+include crd.Makefile
 
 # gcloud.Makefile provides default values for
 # REGISTRY and NAMESPACE derived from local
 # gcloud and kubectl environments.
-include ./marketplace-k8s-app-tools/gcloud.Makefile
+include gcloud.Makefile
 
 # marketplace.Makefile provides targets such as
 # ".build/marketplace/deployer/envsubst" to build the base
 # deployer images locally.
-include ./marketplace-k8s-app-tools/marketplace.Makefile
+include marketplace.Makefile
 
 # ubbagent.Makefile provides ".build/ubbagent/ubbagent"
 # target to build the ubbagent image locally.
-include ./marketplace-k8s-app-tools/var.Makefile
+include var.Makefile
 
 # app.Makefile provides the main targets for installing the
 # application.
 # It requires several APP_* variables defined as followed.
-include ./marketplace-k8s-app-tools/app.Makefile
+#include ./makefiles/app.Makefile
 
 NAME ?= conjur
 

--- a/Makefile
+++ b/Makefile
@@ -35,14 +35,14 @@ NGINX_IMAGE ?= $(REGISTRY)/$(PREFIX)/nginx:$(TAG)
 
 APP_PARAMETERS ?= { \
   "name": "$(NAME)", \
-  "namespace": "$(NAMESPACE)", \
-  "conjur.image": "$(CONJUR_IMAGE)", \
-  "postgres.image": "$(POSTGRES_IMAGE)" \
-  "nginx.image": "$(NGINX_IMAGE)" \
+  "namespace": "$(NAMESPACE)" \
 }
 TESTER_IMAGE ?= $(REGISTRY)/$(PREFIX)/tester:$(TAG)
 APP_TEST_PARAMETERS ?= { \
-  "tester.image": "$(TESTER_IMAGE)" \
+  "tester.image": "$(TESTER_IMAGE)", \
+	"conjuross.image.tag": "$(TAG)", \
+	"conjuross.nginx.tag": "$(TAG)", \
+	"conjuross.postgres.tag": "$(TAG)" \
 }
 
 # Extend the target as defined in app.Makefile to

--- a/README.md
+++ b/README.md
@@ -89,8 +89,10 @@ export NAMESPACE=conjur
 Configure the container images:
 
 ```shell
-export IMAGE_CONJUR="gcr.io/cloud-marketplace/cyberark/conjur-open-source:1.0"
-export IMAGE_POSTGRES="gcr.io/cloud-marketplace/cyberark/conjur-open-source/postgres:1.0"
+export TAG_VERSION=1.3
+export IMAGE_CONJUR="gcr.io/cloud-marketplace/cyberark/conjur-open-source:$TAG_VERSION"
+export IMAGE_POSTGRES="gcr.io/cloud-marketplace/cyberark/conjur-open-source/postgres:$TAG_VERSION"
+export IMAGE_NGINX="gcr.io/cloud-marketplace/cyberark/conjur-open-source/nginx:$TAG_VERSION"
 ```
 
 The images above are referenced by
@@ -102,7 +104,7 @@ until you are ready to upgrade. To get the digest for the image, use the
 following script:
 
 ```shell
-for i in "IMAGE_CONJUR" "IMAGE_POSTGRES"; do
+for i in "IMAGE_CONJUR" "IMAGE_POSTGRES" "IMAGE_NGINX"; do
   repo=$(echo ${!i} | cut -d: -f1);
   digest=$(docker pull ${!i} | sed -n -e 's/Digest: //p');
   export $i="$repo@$digest";
@@ -159,7 +161,7 @@ $ kubectl get po -l app=$name-conjur
 conjur-d76f44b64-rkxff   1/1       Running   0          16m
 
 # Create a Conjur account
-$ kubectl exec conjur-d76f44b64-rkxff conjurctl account create quick-start
+$ kubectl exec conjur-d76f44b64-rkxff -c conjur-oss conjurctl account create quick-start
 Created new account account 'quick-start'
 Token-Signing Public Key: -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv9+iXUFZISHlZfGrkio5
@@ -201,7 +203,7 @@ $ docker run --rm -it --entrypoint bash cyberark/conjur-cli:5
 
 # conjur init -u [EXTERNAL_IP] -a quick-start # or whatever account you created
 # conjur authn login -u admin
-Please enter admin\'s password (it will not be echoed):
+Please enter admin's password (it will not be echoed):
 Logged in
 
 # conjur authn whoami

--- a/app.Makefile
+++ b/app.Makefile
@@ -1,0 +1,122 @@
+ifndef __APP_MAKEFILE__
+
+__APP_MAKEFILE__ := included
+
+
+makefile_dir := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+include $(makefile_dir)/common.Makefile
+include $(makefile_dir)/var.Makefile
+
+
+# Extracts the name property from APP_PARAMETERS.
+define name_parameter
+$(shell echo '$(APP_PARAMETERS)' \
+    | docker run -i --entrypoint=/bin/print_config.py --rm $(APP_DEPLOYER_IMAGE) --values_mode stdin --xtype NAME)
+endef
+
+
+# Extracts the namespace property from APP_PARAMETERS.
+define namespace_parameter
+$(shell echo '$(APP_PARAMETERS)' \
+    | docker run -i --entrypoint=/bin/print_config.py --rm $(APP_DEPLOYER_IMAGE) --values_mode stdin --xtype NAMESPACE)
+endef
+
+
+# Combines APP_PARAMETERS and APP_TEST_PARAMETERS.
+define combined_parameters
+$(shell echo '$(APP_PARAMETERS)' '$(APP_TEST_PARAMETERS)' \
+    | docker run -i --entrypoint=/usr/bin/jq --rm $(APP_DEPLOYER_IMAGE) -s '.[0] * .[1]')
+endef
+
+
+##### Helper targets #####
+
+
+.build/app: | .build
+	mkdir -p "$@"
+
+
+# Always update the dev script to make sure it's up to date.
+# There isn't currently a way to detect if the dev container has changed.
+.PHONY: .build/app/dev
+.build/app/dev: .build/var/MARKETPLACE_TOOLS_TAG \
+              | .build/app
+	docker run \
+	    "gcr.io/cloud-marketplace-tools/k8s/dev:$(MARKETPLACE_TOOLS_TAG)" \
+	    cat /scripts/dev > "$@"
+	chmod a+x "$@"
+
+
+########### Main  targets ###########
+
+
+# Builds the application containers and push them to the registry.
+# Including Makefile can extend this target. This target is
+# a prerequisite for install.
+.PHONY: app/build
+app/build:: ;
+
+
+# Installs the application into target namespace on the cluster.
+.PHONY: app/install
+app/install:: app/build \
+              .build/var/APP_DEPLOYER_IMAGE \
+              .build/var/APP_PARAMETERS \
+              .build/var/MARKETPLACE_TOOLS_TAG \
+              | .build/app/dev
+	$(call print_target)
+	.build/app/dev \
+	    /scripts/install \
+	        --deployer='$(APP_DEPLOYER_IMAGE)' \
+	        --parameters='$(APP_PARAMETERS)' \
+	        --entrypoint="/bin/deploy.sh"
+
+
+# Installs the application into target namespace on the cluster.
+.PHONY: app/install-test
+app/install-test:: app/build \
+                   .build/var/APP_DEPLOYER_IMAGE \
+                   .build/var/APP_PARAMETERS \
+                   .build/var/APP_TEST_PARAMETERS \
+                   .build/var/MARKETPLACE_TOOLS_TAG \
+	           | .build/app/dev
+	$(call print_target)
+	.build/app/dev \
+	    /scripts/install \
+	        --deployer='$(APP_DEPLOYER_IMAGE)' \
+	        --parameters='$(call combined_parameters)' \
+	        --entrypoint="/bin/deploy_with_tests.sh"
+
+
+# Uninstalls the application from the target namespace on the cluster.
+.PHONY: app/uninstall
+app/uninstall: .build/var/APP_DEPLOYER_IMAGE \
+               .build/var/APP_PARAMETERS
+	$(call print_target)
+	kubectl delete 'application/$(call name_parameter)' \
+	    --namespace='$(call namespace_parameter)' \
+	    --ignore-not-found
+
+
+# Runs the verification pipeline.
+.PHONY: app/verify
+app/verify: app/build \
+            .build/var/APP_DEPLOYER_IMAGE \
+            .build/var/APP_PARAMETERS \
+            .build/var/APP_TEST_PARAMETERS \
+            .build/var/MARKETPLACE_TOOLS_TAG \
+            | .build/app/dev
+	$(call print_target)
+	.build/app/dev \
+	    /scripts/verify \
+	          --deployer='$(APP_DEPLOYER_IMAGE)' \
+	          --parameters='$(call combined_parameters)'
+
+
+# Runs diagnostic tool to make sure your environment is properly setup.
+app/doctor: | .build/app/dev
+	$(call print_target)
+	.build/app/dev /scripts/doctor.py
+
+
+endif

--- a/apptest/deployer/conjur/templates/tester.yaml
+++ b/apptest/deployer/conjur/templates/tester.yaml
@@ -32,9 +32,9 @@ metadata:
 data:
   run.sh: |-
     set -x
-    endpoint="https://{{ .Values.conjuross.fullnameOverride }}"
+    endpoint=https://{{ index .Values "conjur-oss" "fullnameOverride" }}
     echo GET $endpoint
-    http_status_code=$(curl --insecure -o /dev/null -s -w "%{http_code}\n" $endpoint)
+    http_status_code=$(curl --insecure -s -o /dev/null -w "%{http_code}\n" $endpoint)
     echo "Expected http status code: 200"
     echo "Actual http status code: $http_status_code"
     if [[ "$http_status_code" == "200" ]]; then

--- a/apptest/deployer/conjur/templates/tester.yaml
+++ b/apptest/deployer/conjur/templates/tester.yaml
@@ -32,9 +32,9 @@ metadata:
 data:
   run.sh: |-
     set -x
-    endpoint="http://{{ .Values.conjuross.fullnameOverride }}"
+    endpoint="https://{{ .Values.conjuross.fullnameOverride }}"
     echo GET $endpoint
-    http_status_code=$(curl -o /dev/null -s -w "%{http_code}\n" $endpoint)
+    http_status_code=$(curl --insecure -o /dev/null -s -w "%{http_code}\n" $endpoint)
     echo "Expected http status code: 200"
     echo "Actual http status code: $http_status_code"
     if [[ "$http_status_code" == "200" ]]; then

--- a/apptest/deployer/conjur/values.yaml
+++ b/apptest/deployer/conjur/values.yaml
@@ -10,3 +10,15 @@ conjuross:
   serviceAccount:
     create: false
     name:
+
+  image:
+    repository: gcr.io/conjur-gke-dev/cyberark
+    tag: "1.3"
+
+  nginx:
+    repository: gcr.io/conjur-gke-dev/cyberark/conjur-open-source/nginx
+    tag: "1.3"
+
+  postgres:
+    repository: gcr.io/conjur-gke-dev/cyberark/conjur-open-source/postgres
+    tag: "1.3"

--- a/apptest/deployer/conjur/values.yaml
+++ b/apptest/deployer/conjur/values.yaml
@@ -1,5 +1,5 @@
 tester:
   image: gcr.io/cyberark/tester:1.0
 
-conjuross:
+conjur-oss:
   fullnameOverride: conjur-conjur-oss

--- a/apptest/deployer/conjur/values.yaml
+++ b/apptest/deployer/conjur/values.yaml
@@ -3,22 +3,3 @@ tester:
 
 conjuross:
   fullnameOverride: conjur-conjur-oss
-
-  rbac:
-    create: false
-  
-  serviceAccount:
-    create: false
-    name:
-
-  image:
-    repository: gcr.io/conjur-gke-dev/cyberark
-    tag: "1.3"
-
-  nginx:
-    repository: gcr.io/conjur-gke-dev/cyberark/conjur-open-source/nginx
-    tag: "1.3"
-
-  postgres:
-    repository: gcr.io/conjur-gke-dev/cyberark/conjur-open-source/postgres
-    tag: "1.3"

--- a/apptest/deployer/conjur/values.yaml
+++ b/apptest/deployer/conjur/values.yaml
@@ -3,3 +3,10 @@ tester:
 
 conjuross:
   fullnameOverride: conjur-conjur-oss
+
+  rbac:
+    create: false
+  
+  serviceAccount:
+    create: false
+    name:

--- a/apptest/deployer/schema.yaml
+++ b/apptest/deployer/schema.yaml
@@ -4,28 +4,29 @@ properties:
     default: $REGISTRY/tester:$TAG
     x-google-marketplace:
       type: IMAGE
+
   conjuross.ssl.hostname:
     type: string
     default: "conjurtest.myorg.com"
     title: Certificate Common Name
-  conjuross.serviceAccount.name:
+
+  conjur.image:
     type: string
-    default: "conjur-authenticator"
-  conjuross.image.repository:
+    default: $REGISTRY/cyberark:$TAG
+    x-google-marketplace:
+      type: IMAGE
+      image:
+        generatedProperties:
+          splitByColon:
+            before: image.repository
+            after: image.tag
+  postgres.image:
     type: string
-    default: gcr.io/conjur-gke-dev/cyberark
-  conjuross.image.tag:
-    type: string
-    default: "1.3"
-  conjuross.nginx.repository:
-    type: string
-    default: gcr.io/conjur-gke-dev/cyberark/conjur-open-source/nginx
-  conjuross.nginx.tag:
-    type: string
-    default: "1.3"
-  conjuross.postgres.repository:
-    type: string
-    default: gcr.io/conjur-gke-dev/cyberark/conjur-open-source/postgres
-  conjuross.postgres.tag:
-    type: string
-    default: "1.3"
+    default: $REGISTRY/cyberark/postgres:$TAG
+    x-google-marketplace:
+      type: IMAGE
+      image:
+        generatedProperties:
+          splitByColon:
+            before: postgres.repository
+            after: postgres.tag

--- a/apptest/deployer/schema.yaml
+++ b/apptest/deployer/schema.yaml
@@ -5,7 +5,7 @@ properties:
     x-google-marketplace:
       type: IMAGE
 
-  conjuross.ssl.hostname:
+  conjur-oss.ssl.hostname:
     type: string
     default: "conjurtest.myorg.com"
     title: Certificate Common Name

--- a/apptest/deployer/schema.yaml
+++ b/apptest/deployer/schema.yaml
@@ -8,3 +8,6 @@ properties:
     type: string
     default: "conjurtest.myorg.com"
     title: Certificate Common Name
+  conjuross.serviceAccount.name:
+    type: string
+    default: "conjur-authenticator"

--- a/apptest/deployer/schema.yaml
+++ b/apptest/deployer/schema.yaml
@@ -4,3 +4,7 @@ properties:
     default: $REGISTRY/tester:$TAG
     x-google-marketplace:
       type: IMAGE
+  conjuross.ssl.hostname:
+    type: string
+    default: "conjurtest.myorg.com"
+    title: Certificate Common Name

--- a/apptest/deployer/schema.yaml
+++ b/apptest/deployer/schema.yaml
@@ -11,3 +11,21 @@ properties:
   conjuross.serviceAccount.name:
     type: string
     default: "conjur-authenticator"
+  conjuross.image.repository:
+    type: string
+    default: gcr.io/conjur-gke-dev/cyberark
+  conjuross.image.tag:
+    type: string
+    default: "1.3"
+  conjuross.nginx.repository:
+    type: string
+    default: gcr.io/conjur-gke-dev/cyberark/conjur-open-source/nginx
+  conjuross.nginx.tag:
+    type: string
+    default: "1.3"
+  conjuross.postgres.repository:
+    type: string
+    default: gcr.io/conjur-gke-dev/cyberark/conjur-open-source/postgres
+  conjuross.postgres.tag:
+    type: string
+    default: "1.3"

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,23 @@
+FROM google/cloud-sdk
+
+RUN mkdir -p /src
+WORKDIR /src
+
+# Install Docker client
+RUN apt-get update && \
+    apt-get install -y apt-transport-https \
+                       ca-certificates \
+                       curl \
+                       gnupg2 \
+                       software-properties-common \
+                       wget && \
+    curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | apt-key add - && \
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable" && \
+    apt-get update && \
+    apt-get install -y docker-ce && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV KUBECTL_VERSION=1.13.2
+RUN wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
+    chmod +x /usr/local/bin/kubectl

--- a/ci/gke_test
+++ b/ci/gke_test
@@ -1,35 +1,58 @@
-#!/usr/bin/env bash
-
+#!/bin/bash
 set -euo pipefail
 
-CURRENT_DIR=$(dirname $0)
 TOOLS_IMAGE_NAME="conjur-gke-marketplace-kubectl"
+TMP_DIR="$(pwd)/.tmp"
+BIN_DIR="${TMP_DIR}/bin"
 
-function run_in_docker() {
+mkdir -p "${BIN_DIR}"
+mkdir -p "${TMP_DIR}/.kube"
+mkdir -p "${TMP_DIR}/.config"
+
+cat > "${BIN_DIR}/kubectl" <<EOF
   docker run --rm \
-    -e DOCKER_REGISTRY_URL \
-    -e DOCKER_REGISTRY_PATH \
-    -e GCLOUD_SERVICE_KEY=/tmp$GCLOUD_SERVICE_KEY \
-    -e GCLOUD_CLUSTER_NAME \
-    -e GCLOUD_ZONE \
-    -e GCLOUD_PROJECT_NAME \
-    -v $GCLOUD_SERVICE_KEY:/tmp$GCLOUD_SERVICE_KEY \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    -v ~/.config:/root/.config \
-    -v "$PWD/..":/src \
-    -w /src \
-    "$TOOLS_IMAGE_NAME" \
-    bash -exc "
-      ./ci/platform_login
-      $1
-    "
-}
+    -v "${TMP_DIR}/.kube:/root/.kube" \
+    -v "${TMP_DIR}/.config:/root/.config" \
+    --entrypoint /usr/local/bin/kubectl \
+    "${TOOLS_IMAGE_NAME}" \
+    "\$@"
+EOF
+chmod +x "${BIN_DIR}/kubectl"
+
+cat > "${BIN_DIR}/gcloud" <<EOF
+  docker run --rm \
+    --ipc="host" \
+    -v "${TMP_DIR}/.kube:/root/.kube" \
+    -v "${TMP_DIR}/.config:/root/.config" \
+    --entrypoint /usr/bin/gcloud \
+    "${TOOLS_IMAGE_NAME}" \
+    "\$@"
+EOF
+chmod +x "${BIN_DIR}/gcloud"
+
+export PATH="${BIN_DIR}:${PATH}"
 
 echo "Building kubectl image..."
 docker pull google/cloud-sdk
-docker build -t "$TOOLS_IMAGE_NAME" \
+docker build -t "${TOOLS_IMAGE_NAME}" \
              -f Dockerfile \
              .
 
+./platform_login
+
+export KUBE_CONFIG="${TMP_DIR}/.kube/config"
+export GCLOUD_CONFIG="${TMP_DIR}/.config/gcloud"
+
+# Fix permissions on files created within Docker
+docker run --rm \
+    -v "${TMP_DIR}/.kube:/root/.kube" \
+    -v "${TMP_DIR}/.config:/root/.config" \
+    "${TOOLS_IMAGE_NAME}" \
+    bash -c "chown ${UID} -R /root/.kube/config /root/.config/*"
+
 echo "Running build and tests..."
-run_in_docker "./test.sh"
+pushd ../
+  trap popd EXIT
+  ./test.sh
+  trap - EXIT
+popd

--- a/ci/gke_test
+++ b/ci/gke_test
@@ -3,8 +3,33 @@
 set -euo pipefail
 
 CURRENT_DIR=$(dirname $0)
+TOOLS_IMAGE_NAME="conjur-gke-marketplace-kubectl"
 
-echo "Running tests..."
-pushd $CURRENT_DIR/.. >/dev/null
-  ./test.sh
-popd >/dev/null
+function run_in_docker() {
+  docker run --rm \
+    -e DOCKER_REGISTRY_URL \
+    -e DOCKER_REGISTRY_PATH \
+    -e GCLOUD_SERVICE_KEY=/tmp$GCLOUD_SERVICE_KEY \
+    -e GCLOUD_CLUSTER_NAME \
+    -e GCLOUD_ZONE \
+    -e GCLOUD_PROJECT_NAME \
+    -v $GCLOUD_SERVICE_KEY:/tmp$GCLOUD_SERVICE_KEY \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v ~/.config:/root/.config \
+    -v "$PWD/..":/src \
+    -w /src \
+    "$TOOLS_IMAGE_NAME" \
+    bash -exc "
+      ./ci/platform_login
+      $1
+    "
+}
+
+echo "Building kubectl image..."
+docker pull google/cloud-sdk
+docker build -t "$TOOLS_IMAGE_NAME" \
+             -f Dockerfile \
+             .
+
+echo "Running build and tests..."
+run_in_docker "./test.sh"

--- a/ci/gke_test
+++ b/ci/gke_test
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CURRENT_DIR=$(dirname $0)
+
+echo "Running tests..."
+pushd $CURRENT_DIR/.. >/dev/null
+  ./test.sh
+popd >/dev/null

--- a/ci/platform_login
+++ b/ci/platform_login
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+echo "Logging into GKE and Docker repo..."
+gcloud auth activate-service-account \
+  --key-file $GCLOUD_SERVICE_KEY
+gcloud container clusters get-credentials \
+  $GCLOUD_CLUSTER_NAME \
+  --zone $GCLOUD_ZONE \
+  --project $GCLOUD_PROJECT_NAME
+docker login $DOCKER_REGISTRY_URL \
+  -u oauth2accesstoken \
+  -p "$(gcloud auth print-access-token)"
+
+echo "Logged into remote resources."

--- a/ci/secrets.yml
+++ b/ci/secrets.yml
@@ -1,5 +1,3 @@
-KUBECTL_CLI_URL: curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.13.2/bin/linux/amd64/kubectl
-
 GCLOUD_CLUSTER_NAME: !var ci/google-container-engine-testbed/gcloud-cluster-name
 GCLOUD_ZONE: !var ci/google-container-engine-testbed/gcloud-zone
 GCLOUD_PROJECT_NAME: !var ci/google-container-engine-testbed/gcloud-project-name

--- a/ci/secrets.yml
+++ b/ci/secrets.yml
@@ -1,0 +1,9 @@
+KUBECTL_CLI_URL: curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.13.2/bin/linux/amd64/kubectl
+
+GCLOUD_CLUSTER_NAME: !var ci/google-container-engine-testbed/gcloud-cluster-name
+GCLOUD_ZONE: !var ci/google-container-engine-testbed/gcloud-zone
+GCLOUD_PROJECT_NAME: !var ci/google-container-engine-testbed/gcloud-project-name
+GCLOUD_SERVICE_KEY: !var:file ci/google-container-engine-testbed/gcloud-service-key
+
+DOCKER_REGISTRY_URL: gcr.io
+DOCKER_REGISTRY_PATH: gcr.io/conjur-gke-dev

--- a/common.Makefile
+++ b/common.Makefile
@@ -1,0 +1,1 @@
+marketplace-k8s-app-tools/common.Makefile

--- a/conjur/Chart.yaml
+++ b/conjur/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A Helm chart for CyberArk Conjur
 name: conjur
-version: 1.2.0
+version: 1.3.6
 icon: https://xebialabs-clients-iglusjax.stackpathdns.com/assets/files/logos/CyberArkConjurLogoWhiteBlue.png

--- a/conjur/requirements.yaml
+++ b/conjur/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: conjur-oss
-    version: "0.2.2"
+    version: "1.3.6"
     repository: https://cyberark.github.io/helm-charts
     alias: conjuross  # aliased to remove '-' in conjur-oss. Downstream tools have problems without this.

--- a/conjur/requirements.yaml
+++ b/conjur/requirements.yaml
@@ -2,4 +2,3 @@ dependencies:
   - name: conjur-oss
     version: "1.3.6"
     repository: https://cyberark.github.io/helm-charts
-    alias: conjuross  # aliased to remove '-' in conjur-oss. Downstream tools have problems without this.

--- a/conjur/templates/application.yaml
+++ b/conjur/templates/application.yaml
@@ -27,17 +27,6 @@ spec:
     - description: Getting Started
       url: https://www.conjur.org/get-started/
     notes: |-
-      # Expose Conjur service
-
-        By default, the application does not have an external IP. Run the
-        following command to expose an external IP:
-
-        ```
-        kubectl patch svc "{{ .Release.Name }}-conjur" \
-          --namespace {{ .Release.Namespace }} \
-          -p '{"spec": {"type": "LoadBalancer"}}'
-        ```
-
       # Access Conjur
 
       Get the external IP of the Conjur service and visit
@@ -49,7 +38,7 @@ spec:
           svc {{ .Release.Name }}-conjur \
           -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 
-        echo "http://${SERVICE_IP}"
+        echo "https://${SERVICE_IP}"
         ```
 
         Note that it might take some time for the external IP to be provisioned.

--- a/conjur/templates/application.yaml
+++ b/conjur/templates/application.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   descriptor:
     type: Conjur
-    version: '1.2.0'
+    version: '1.3.4'
     description: |-
       CyberArk Conjur automatically secures secrets used by privileged users and machine identities.
 
@@ -59,7 +59,7 @@ spec:
       To create an initial account and login, follow the instructions here:
         https://www.conjur.org/get-started/install-conjur.html#install-and-configure
 
-        Use `kubectl exec <conjur-pod> ...` instead of `docker-compose exec ...`.
+        Use `kubectl exec <conjur-pod> -c conjur-oss ...` instead of `docker-compose exec ...`.
   selector:
     matchLabels:
       app.kubernetes.io/name: "{{ .Release.Name }}"

--- a/conjur/templates/application.yaml
+++ b/conjur/templates/application.yaml
@@ -42,13 +42,50 @@ spec:
         ```
 
         Note that it might take some time for the external IP to be provisioned.
+        Once provisioned, create an A record mapping this IP to the common name
+        specified during configuration.
 
       # Configure Conjur
 
       To create an initial account and login, follow the instructions here:
         https://www.conjur.org/get-started/install-conjur.html#install-and-configure
 
-        Use `kubectl exec <conjur-pod> -c conjur-oss ...` instead of `docker-compose exec ...`.
+        ```
+        export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} \
+                                          -l "app={{ template "conjur-oss.name" . }},release={{ .Release.Name }}" \
+                                          -o jsonpath="{.items[0].metadata.name}")
+        kubectl exec $POD_NAME --container={{ .Chart.Name }} conjurctl account create {{ .Values.account | quote }}
+        ```
+
+        Note that the conjurctl account create command gives you the
+        public key and admin API key for the account administrator you created.
+        Back them up in a safe location.
+
+      # Connect to Conjur
+
+      Start a container with Conjur CLI and authenticate with the new user:
+
+      ```
+      docker run --rm -it --entrypoint bash cyberark/conjur-cli:5
+
+      # Here ENDPOINT is the DNS name https endpoint for your Conjur service.
+      # NOTE: Ensure that the target endpoint matches at least one of the expected server
+      #       SSL certificate names otherwise SSL verification will fail and you will not
+      #       be able to log in.
+      # NOTE: Also ensure that the URL does not contain a slash (`/`) at the end of the URL
+      conjur init -u <ENDPOINT> -a {{ index .Values "conjur-oss" "account" | quote }}
+
+      # API key here is the key that creation of the account provided you in step #2
+      conjur authn login -u admin -p <API_KEY>
+
+      # Check that you are identified as the admin user
+      conjur authn whoami
+      ```
+
+      # Next Steps
+
+      - Go through the Conjur Tutorials: https://www.conjur.org/tutorials/
+      - View Conjur’s API Documentation: https://www.conjur.org/api.html
   selector:
     matchLabels:
       app.kubernetes.io/name: "{{ .Release.Name }}"

--- a/conjur/values.yaml
+++ b/conjur/values.yaml
@@ -8,8 +8,12 @@ conjuross:
 
   image:
     repository: gcr.io/cloud-marketplace/cyberark/conjur-open-source
-    tag: "1.0"
+    tag: "1.3"
+
+  nginx:
+    repository: gcr.io/cloud-marketplace/cyberark/conjur-open-source/nginx
+    tag: "1.3"
 
   postgres:
     repository: gcr.io/cloud-marketplace/cyberark/conjur-open-source/postgres
-    tag: "1.0"
+    tag: "1.3"

--- a/conjur/values.yaml
+++ b/conjur/values.yaml
@@ -3,8 +3,15 @@
 # Any values from the conjur-oss Chart can be overridden here
 
 conjuross:
+  account: default
+  authenticators: authn
   dataKey: ""  # This will be generated for you, see ../schema.yaml.
   databaseUrl: ""
+  persistentVolumeSize: 8Gi
+
+  ssl:
+    expiration: 365 # days
+    hostname: "conjur.myorg.com"
 
   image:
     repository: gcr.io/cloud-marketplace/cyberark/conjur-open-source

--- a/conjur/values.yaml
+++ b/conjur/values.yaml
@@ -3,24 +3,11 @@
 # Any values from the conjur-oss Chart can be overridden here
 
 conjuross:
-  account: default
-  authenticators: authn
   dataKey: ""  # This will be generated for you, see ../schema.yaml.
   databaseUrl: ""
-  persistentVolumeSize: 8Gi
 
-  ssl:
-    expiration: 365 # days
-    hostname: "conjur.myorg.com"
+  rbac:
+    create: false
 
-  image:
-    repository: gcr.io/cloud-marketplace/cyberark/conjur-open-source
-    tag: "1.3"
-
-  nginx:
-    repository: gcr.io/cloud-marketplace/cyberark/conjur-open-source/nginx
-    tag: "1.3"
-
-  postgres:
-    repository: gcr.io/cloud-marketplace/cyberark/conjur-open-source/postgres
-    tag: "1.3"
+  serviceAccount:
+    create: false

--- a/conjur/values.yaml
+++ b/conjur/values.yaml
@@ -2,7 +2,7 @@
 # From conjur-oss: https://github.com/cyberark/conjur-oss-helm-chart/blob/master/conjur-oss/values.yaml
 # Any values from the conjur-oss Chart can be overridden here
 
-conjuross:
+conjur-oss:
   dataKey: ""  # This will be generated for you, see ../schema.yaml.
   databaseUrl: ""
 

--- a/crd.Makefile
+++ b/crd.Makefile
@@ -1,0 +1,18 @@
+ifndef __CRD_MAKEFILE__
+
+__CRD_MAKEFILE__ := included
+
+include common.Makefile
+
+# Installs the application CRD on the cluster.
+.PHONY: crd/install
+crd/install:
+	kubectl apply -f "https://raw.githubusercontent.com/GoogleCloudPlatform/marketplace-k8s-app-tools/master/crd/app-crd.yaml"
+
+
+# Uninstalls the application CRD from the cluster.
+.PHONY: crd/uninstall
+crd/uninstall:
+	kubectl delete -f "https://raw.githubusercontent.com/GoogleCloudPlatform/marketplace-k8s-app-tools/master/crd/app-crd.yaml"
+
+endif

--- a/deployer/Dockerfile
+++ b/deployer/Dockerfile
@@ -1,6 +1,8 @@
 FROM launcher.gcr.io/google/debian9 AS build
 
-RUN apt-get update \
+# Cachebuster is used to forcefully invalidate the cache when needed
+RUN echo "cachebuster-20190116" >/dev/null \
+    && apt-get update \
     && apt-get install -y --no-install-recommends gettext curl
 
 RUN curl -L -o /tmp/helm.tgz https://storage.googleapis.com/kubernetes-helm/helm-v2.6.1-linux-amd64.tar.gz && \

--- a/deployer/Dockerfile
+++ b/deployer/Dockerfile
@@ -1,7 +1,7 @@
 FROM launcher.gcr.io/google/debian9 AS build
 
 # Cachebuster is used to forcefully invalidate the cache when needed
-RUN echo "cachebuster-20190116" >/dev/null \
+RUN echo "cachebuster-20190118" >/dev/null \
     && apt-get update \
     && apt-get install -y --no-install-recommends gettext curl
 

--- a/deployer/Dockerfile
+++ b/deployer/Dockerfile
@@ -3,7 +3,7 @@ FROM launcher.gcr.io/google/debian9 AS build
 RUN apt-get update \
     && apt-get install -y --no-install-recommends gettext curl
 
-RUN curl -L -o /tmp/helm.tgz https://storage.googleapis.com/kubernetes-helm/helm-v2.5.1-linux-amd64.tar.gz && \
+RUN curl -L -o /tmp/helm.tgz https://storage.googleapis.com/kubernetes-helm/helm-v2.6.1-linux-amd64.tar.gz && \
     cd /tmp && \
     tar xvzf helm.tgz && \
     cp linux-amd64/helm /usr/local/bin/helm && \
@@ -41,7 +41,7 @@ RUN cat /tmp/test/schema.yaml \
     && mv /tmp/test/schema.yaml.new /tmp/test/schema.yaml
 
 
-FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:v0.6.2
+FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:0.7.0
 COPY --from=build /tmp/conjur.tar.gz /data/chart/
 COPY --from=build /tmp/test/conjur.tar.gz /data-test/chart/
 COPY --from=build /tmp/schema.yaml /data/

--- a/deployer/Dockerfile.dev
+++ b/deployer/Dockerfile.dev
@@ -1,0 +1,50 @@
+FROM launcher.gcr.io/google/debian9 AS build
+
+# Cachebuster is used to forcefully invalidate the cache when needed
+RUN echo "cachebuster-20190118" >/dev/null \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gettext curl
+
+RUN curl -L -o /tmp/helm.tgz https://storage.googleapis.com/kubernetes-helm/helm-v2.6.1-linux-amd64.tar.gz && \
+    cd /tmp && \
+    tar xvzf helm.tgz && \
+    cp linux-amd64/helm /usr/local/bin/helm && \
+    rm -rf helm.tgz linux-amd64
+
+COPY ./conjur /tmp/chart
+WORKDIR /tmp/chart
+
+ARG CONJUR_OSS_PACKAGE
+COPY .build/${CONJUR_OSS_PACKAGE} /tmp/chart/charts/
+RUN sed -i 's/repository: .*//g' requirements.yaml \
+    && helm init --client-only
+
+WORKDIR /tmp
+RUN tar -czvf conjur.tar.gz chart
+
+COPY apptest/deployer/conjur /tmp/test/chart
+WORKDIR /tmp/test
+
+RUN tar -czvf conjur.tar.gz chart
+
+COPY schema.yaml /tmp/schema.yaml
+COPY apptest/deployer/schema.yaml /tmp/test/schema.yaml
+
+# Provide registry prefix and tag for default values for images.
+ARG REGISTRY
+ARG TAG
+RUN cat /tmp/schema.yaml \
+    | env -i "REGISTRY=$REGISTRY" "TAG=$TAG" envsubst \
+    > /tmp/schema.yaml.new \
+    && mv /tmp/schema.yaml.new /tmp/schema.yaml
+RUN cat /tmp/test/schema.yaml \
+    | env -i "REGISTRY=$REGISTRY" "TAG=$TAG" envsubst \
+    > /tmp/test/schema.yaml.new \
+    && mv /tmp/test/schema.yaml.new /tmp/test/schema.yaml
+
+
+FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:0.7.0
+COPY --from=build /tmp/conjur.tar.gz /data/chart/
+COPY --from=build /tmp/test/conjur.tar.gz /data-test/chart/
+COPY --from=build /tmp/schema.yaml /data/
+COPY --from=build /tmp/test/schema.yaml /data-test/

--- a/gcloud.Makefile
+++ b/gcloud.Makefile
@@ -1,0 +1,1 @@
+marketplace-k8s-app-tools/gcloud.Makefile

--- a/marketplace.Makefile
+++ b/marketplace.Makefile
@@ -1,0 +1,1 @@
+marketplace-k8s-app-tools/marketplace.Makefile

--- a/schema.yaml
+++ b/schema.yaml
@@ -29,6 +29,14 @@ properties:
           splitByColon:
             before: postgres.repository
             after: postgres.tag
+  conjuross.account:
+    type: string
+    default: default
+    title: Conjur Account
+    description: >-
+      If using the Conjur authenticator for Kubernetes, an account name must be
+      specified. This allows for authentication of roles under the given account.
+      Note that this field is strictly a reference; it will not create an account.
   conjuross.authenticators:
     type: string
     default: authn
@@ -51,6 +59,19 @@ properties:
     description: >-
       PostgreSQL connection string for Conjur. If none is provided, a Postgres
       deployment will be created for you. This value is stored in a Kubernetess secret.
+  conjuross.persistentVolumeSize:
+    type: string
+    default: 8Gi
+    title: Storage
+    description: Size of disk to be used for persistent PostgreSQL database
+  conjuross.ssl.expiration:
+    type: integer
+    title: Certificate Expiration (days)
+    default: 365
+    minimum: 1
+  conjuross.ssl.hostname:
+    type: string
+    title: Certificate Common Name
 
 required:
 - name
@@ -58,3 +79,6 @@ required:
 - conjur.image
 - postgres.image
 - conjuross.dataKey
+- conjuross.persistentVolumeSize
+- conjuross.ssl.expiration
+- conjuross.ssl.hostname

--- a/schema.yaml
+++ b/schema.yaml
@@ -72,6 +72,7 @@ properties:
   conjuross.ssl.hostname:
     type: string
     title: Certificate Common Name
+    description: The external DNS which will be used as the endpoint for the Conjur instance.
 
 required:
 - name

--- a/schema.yaml
+++ b/schema.yaml
@@ -29,7 +29,7 @@ properties:
           splitByColon:
             before: postgres.repository
             after: postgres.tag
-  conjuross.account:
+  conjur-oss.account:
     type: string
     default: default
     title: Conjur Account
@@ -37,14 +37,14 @@ properties:
       If using the Conjur authenticator for Kubernetes, an account name must be
       specified. This allows for authentication of roles under the given account.
       Note that this field is strictly a reference; it will not create an account.
-  conjuross.authenticators:
+  conjur-oss.authenticators:
     type: string
     default: authn
     title: Conjur Authenticators
     description: >-
       Comma-separated list of authenticators to enable on Conjur.
       See the full list at https://docs.conjur.org/Latest/en/Content/Operations/Services/authentication-types.htm.
-  conjuross.dataKey:
+  conjur-oss.dataKey:
     type: string
     title: Conjur Data key
     description: Encryption key for Conjur database.
@@ -53,27 +53,27 @@ properties:
       generatedPassword:
         length: 32
         base64: true
-  conjuross.databaseUrl:
+  conjur-oss.databaseUrl:
     type: string
     title: External PostgreSQL connection (Optional)
     description: >-
       PostgreSQL connection string for Conjur. If none is provided, a Postgres
       deployment will be created for you. This value is stored in a Kubernetess secret.
-  conjuross.persistentVolumeSize:
+  conjur-oss.persistentVolumeSize:
     type: string
     default: 8Gi
     title: Storage
     description: Size of disk to be used for persistent PostgreSQL database
-  conjuross.ssl.expiration:
+  conjur-oss.ssl.expiration:
     type: integer
     title: Certificate Expiration (days)
     default: 365
     minimum: 1
-  conjuross.ssl.hostname:
+  conjur-oss.ssl.hostname:
     type: string
     title: Certificate Common Name
     description: The external DNS which will be used as the endpoint for the Conjur instance.
-  conjuross.serviceAccount.name:
+  conjur-oss.serviceAccount.name:
     type: string
     x-google-marketplace:
       type: SERVICE_ACCOUNT
@@ -100,8 +100,8 @@ required:
 - namespace
 - conjur.image
 - postgres.image
-- conjuross.dataKey
-- conjuross.persistentVolumeSize
-- conjuross.ssl.expiration
-- conjuross.ssl.hostname
-- conjuross.serviceAccount.name
+- conjur-oss.dataKey
+- conjur-oss.persistentVolumeSize
+- conjur-oss.ssl.expiration
+- conjur-oss.ssl.hostname
+- conjur-oss.serviceAccount.name

--- a/schema.yaml
+++ b/schema.yaml
@@ -73,6 +73,27 @@ properties:
     type: string
     title: Certificate Common Name
     description: The external DNS which will be used as the endpoint for the Conjur instance.
+  conjuross.serviceAccount.name:
+    type: string
+    x-google-marketplace:
+      type: SERVICE_ACCOUNT
+      serviceAccount:
+        roles:
+        - type: ClusterRole
+          rulesType: CUSTOM
+          rules:
+          - apiGroups: [""]
+            resources: ["pods", "serviceaccounts"]
+            verbs: ["get", "list"]
+          - apiGroups: ["extensions"]
+            resources: [ "deployments", "replicasets"]
+            verbs: ["get", "list"]
+          - apiGroups: ["apps"]
+            resources: [ "deployments", "statefulsets", "replicasets"]
+            verbs: ["get", "list"]
+          - apiGroups: [""]
+            resources: ["pods/exec"]
+            verbs: ["create", "get"]
 
 required:
 - name
@@ -83,3 +104,4 @@ required:
 - conjuross.persistentVolumeSize
 - conjuross.ssl.expiration
 - conjuross.ssl.hostname
+- conjuross.serviceAccount.name

--- a/test.sh
+++ b/test.sh
@@ -5,6 +5,36 @@ make crd/install
 
 gcloud auth configure-docker
 
+chart_dir=""
+
+while [ "$1" != "" ]; do
+    case $1 in
+        -c | --chart-dir )  shift
+                            chart_dir="${1}"
+                            ;;
+        * )                 >&2 echo "Unknown argument: ${1}"
+                            exit 1
+                            ;;
+    esac
+    shift
+done
+
+if [ "${chart_dir}" != "" ]; then
+  if [[ ! -f "${chart_dir}/Chart.yaml" ]]; then
+    ls -al "${chart_dir}"
+    >&2 echo "ERROR: chart directory does not contain a Chart.yaml file"
+    exit 1
+  fi
+
+  echo "Chart directory specified, switching to dev mode"
+
+  mkdir -p .build
+  helm package -d .build --save=false "${chart_dir}"
+
+  export DOCKERFILE=deployer/Dockerfile.dev
+  export CONJUR_OSS_PACKAGE="$(ls .build | grep conjur-oss)"
+fi
+
 echo "Getting the desired marketplace Docker image..."
 MARKETPLACE_TOOLS_TAG="0.7.0"
 LOCAL_MARKETPLACE_TOOLS_TAG="local-$USER"

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,19 @@
 make clean
 make crd/install
 
+gcloud auth configure-docker
+
+echo "Getting the desired marketplace Docker image..."
+MARKETPLACE_TOOLS_TAG="0.7.0"
+LOCAL_MARKETPLACE_TOOLS_TAG="local-$USER"
+docker pull "gcr.io/cloud-marketplace-tools/k8s/dev:$MARKETPLACE_TOOLS_TAG"
+docker tag "gcr.io/cloud-marketplace-tools/k8s/dev:$MARKETPLACE_TOOLS_TAG" \
+           "gcr.io/cloud-marketplace-tools/k8s/dev:$LOCAL_MARKETPLACE_TOOLS_TAG"
+
+echo "Building/verifying app..."
 env \
   TAG="${CI_COMMIT_SHA:-$(whoami)}" \
   REGISTRY='gcr.io/conjur-gke-dev' \
-  make -e app/verify
+  make -j4 -e app/verify
+
+echo "Done!"

--- a/var.Makefile
+++ b/var.Makefile
@@ -1,0 +1,1 @@
+marketplace-k8s-app-tools/var.Makefile


### PR DESCRIPTION
Massive updates to the code running, building, and testing the artifacts for the marketplace using the latest Conjur OSS version (v1.3.6) though the publishing process is still TBD.