### PR TITLE
Remove `docker login`

### DIFF
--- a/ci/platform_login
+++ b/ci/platform_login
@@ -10,8 +10,5 @@ gcloud container clusters get-credentials \
   $GCLOUD_CLUSTER_NAME \
   --zone $GCLOUD_ZONE \
   --project $GCLOUD_PROJECT_NAME
-docker login $DOCKER_REGISTRY_URL \
-  -u oauth2accesstoken \
-  -p "$(gcloud auth print-access-token)"
 
 echo "Logged into remote resources."


### PR DESCRIPTION
This is no longer needed, Jenkins executors are assumed to already
be logged in.