### PR TITLE
Changed tag target from 1.3.4 to 1.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ include var.Makefile
 include app.Makefile
 
 NAME ?= conjur
-TAG ?= 1.3.4
+TAG ?= 1.3
 REGISTRY ?= gcr.io/conjur-cloud-launcher-onboard
 
 PREFIX ?= cyberark

--- a/conjur/templates/application.yaml
+++ b/conjur/templates/application.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   descriptor:
     type: Conjur
-    version: '1.3.4'
+    version: '1.3'
     description: |-
       CyberArk Conjur automatically secures secrets used by privileged users and machine identities.
 


### PR DESCRIPTION
According to the upstream needs, the patch should not be used yet in the
GKE application.