### PR TITLE
Updates version tag for publishing to Google Marketplace

### DIFF
--- a/conjur/templates/application.yaml
+++ b/conjur/templates/application.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   descriptor:
     type: Conjur
-    version: '1.3'
+    version: '1.4.0'
     description: |-
       CyberArk Conjur automatically secures secrets used by privileged users and machine identities.
 


### PR DESCRIPTION
This change updates the version tag that is used for publishing
images to Google Marketplace.

Background:
When the Jenkins job runs on the master branch, it does a publish
of images to Google Marketplace. The version tag to use for this
publish is determined from this function in the Jenkinsfile:

```
def ReleaseVersion() {
  application = readYaml file: 'conjur/templates/application.yaml'
  return application.spec.descriptor.version
}
```

So the corresponding version value in the application.yaml needs
to be updated.