### PR TITLE
Adds trivy scan of component images in Jenkins pipeline

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,17 @@
+# The CyberArk Google Marketplace App deployer container is based upon
+# the Google deployer_helm:0.10.1 container image, and is subject to
+# the following vulnerabiliities:
+CVE-2019-10220
+CVE-2019-19813
+CVE-2019-19814
+CVE-2019-19816
+
+# The postgres:9.4 container is subject to the following critical
+# vulnerabilities:
+CVE-2005-2541
+CVE-2017-1000082
+
+# The nginx:1.17 container is subject to the following critical
+# vulnerabilities:
+CVE-2005-2541
+CVE-2019-2201


### PR DESCRIPTION
Adds a trivy security scan of Marketplace app component images to project
pipeline to find any Vulnerabilities before publishing to Google Marketplace.

trivy security scans of the following Marketplace app component images
are being add to the project pipeline to find vulnerabilities before publishing to
Google Marketplace:
- deployer
- tester
- nginx
- postgres

A scan of the conjur image is skipped because this image is built and
scanned elsewhere (i.e. for the cyberark/conjur repo builds).

A .trivyignore file is being added for the following remaining
critical vulnerabilities:
- 4 critical vulnerability remaining in Google's deployer_helm container
- 2 critical vulnerabilities in postgres:9.4 container
- 2 critical vulnerabilities in nginx:1.17 container

Reference: https://github.com/aquasecurity/trivy