### PR TITLE
Fixes vulnerabilities in Marketplace app tester image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,8 @@ POSTGRES_SOURCE_IMAGE ?= postgres:10.1
 POSTGRES_IMAGE ?= $(REGISTRY_PREFIX)/postgres:$(TAG)
 NGINX_SOURCE_IMAGE ?= nginx:1.15
 NGINX_IMAGE ?= $(REGISTRY_PREFIX)/nginx:$(TAG)
-DOCKERFILE ?= deployer/Dockerfile
+DEPLOYER_DOCKERFILE ?= deployer/Dockerfile
+TESTER_DOCKERFILE ?= tester/Dockerfile
 
 $(info $$CONJUR_IMAGE is [${CONJUR_IMAGE}])
 $(info $$PREFIX is [${PREFIX}])
@@ -85,15 +86,17 @@ app/build:: .build/conjur/deployer \
 	    --build-arg TAG="$(TAG)" \
 	    --build-arg CONJUR_OSS_PACKAGE="$(CONJUR_OSS_PACKAGE)" \
 	    --tag "$(APP_DEPLOYER_IMAGE)" \
-	    -f "$(DOCKERFILE)" \
+	    -f "$(DEPLOYER_DOCKERFILE)" \
 	    .
 	docker push "$(APP_DEPLOYER_IMAGE)"
 	@touch "$@"
 
 .build/conjur/tester:
 	$(call print_target, $@)
-	docker pull cosmintitei/bash-curl
-	docker tag cosmintitei/bash-curl "$(TESTER_IMAGE)"
+	docker build \
+	    --tag "$(TESTER_IMAGE)" \
+	    -f "$(TESTER_DOCKERFILE)" \
+	    .
 	docker push "$(TESTER_IMAGE)"
 	@touch "$@"
 

--- a/tester/Dockerfile
+++ b/tester/Dockerfile
@@ -1,0 +1,5 @@
+FROM bash:5.0.16
+
+RUN apk add --no-cache curl
+
+CMD ["bash"]


### PR DESCRIPTION
This change uses a more recent bash image as an image baseline
for building the Marketplace app tester. (Note: The app tester is
simply a bash container with curl added.)

Fixes Issue #32