### PR TITLE
Reduces vulnerabilities by updating deployer_helm container

### DIFF
--- a/deployer/Dockerfile
+++ b/deployer/Dockerfile
@@ -43,7 +43,7 @@ RUN cat /tmp/test/schema.yaml \
     && mv /tmp/test/schema.yaml.new /tmp/test/schema.yaml
 
 
-FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:0.10.0
+FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:0.10.1
 COPY --from=build /tmp/conjur.tar.gz /data/chart/
 COPY --from=build /tmp/test/conjur.tar.gz /data-test/chart/
 COPY --from=build /tmp/schema.yaml /data/


### PR DESCRIPTION
This change updates the version of the Google `deployer_helm` container
used as a baseline container in our Google Marketplace app deployer
container from version 0.10.0 to 0.10.1.

This is being done to reduce the number of critical and high
vulnerabilities that are being reported when a trivy scan is run on our
deployer container, as described in Issue #34.

With this change:
- Critical vulnerabilities are reduced from 3 to 1 (unique CVEs)
- High vulnerabilities are reduced from 17 to 14 (unique CVEs)

Addresses Issue #34