### PR TITLE
Build failures for tester image trivy scans are fixed.

### DIFF
--- a/tester/Dockerfile
+++ b/tester/Dockerfile
@@ -1,5 +1,5 @@
-FROM bash:5.0.16
+FROM alpine:3.11.6
 
 RUN apk add --no-cache curl
 
-CMD ["bash"]
+CMD ["sh"]


### PR DESCRIPTION
Fixes [Issue #47](https://github.com/cyberark/conjur-google-cloud-marketplace/issues/47)

Uses alpine:3.11.6 image directly, rather than bash docker image, since
CVE-2020-1967 has been addressed in alpine:3.11.6.